### PR TITLE
Wrap up of issue #10.

### DIFF
--- a/drupalvm/.gitignore
+++ b/drupalvm/.gitignore
@@ -1,0 +1,1 @@
+local_config.js

--- a/drupalvm/components/dialog.js
+++ b/drupalvm/components/dialog.js
@@ -1,0 +1,144 @@
+/**
+ * Class definition for managing Dialog.
+ */
+
+// DVM Dialog class
+(function(context) {
+  "use strict";
+
+  // add Dialog class to DVM scope
+  if (!context.Dialog) {
+    context.Dialog = (function(context) {
+      // private
+      
+      // bootbox element is assigned to this var in create()
+      var dialog = {};
+
+      // settings/configuration object
+      var settings = {
+        auto_scroll: false
+      };
+
+      /**
+       * Returns HTML template for Dialog's content.
+       * @return {[type]} [description]
+       */
+      function template() {
+        var output = '';
+
+        output += '<div class="progress">';
+        output += '  <div class="progress-bar progress-bar-striped active"';
+        output += '       role="progressbar"';
+        output += '       aria-valuemin="0"';
+        output += '       aria-valuemax="100"';
+        output += '       aria-valuenow="0"';
+        output += '       style="width: 0">';
+        output += '    <span class="sr-only">100% Complete</span>';
+        output += '  </div>';
+        output += '</div>';
+
+        output += 'Details';
+        output += '<pre class="processingLog"></pre>';
+
+        return output;
+      }
+
+      // public
+      return {
+        /**
+         * Creates & returns new Dialog object.
+         * 
+         * @return {[type]} [description]
+         */
+        create: function(title, config) {
+          if (typeof title == 'undefined') {
+            title = '';
+          }
+
+          if (typeof config == 'undefined') {
+            config = {};
+          }
+
+          this.setSettings(config);
+
+          dialog = bootbox.dialog({
+            title: title,
+            message: template()
+          });
+
+          return this;
+        },
+
+        /**
+         * Extends existing settings with config object.
+         */
+        setSettings: function (config) {
+          settings = $.extend(settings, config);
+        },
+
+        /**
+         * Updates the progressbar value.
+         * @param {[type]} percentage [description]
+         */
+        setProgress: function (percentage) {
+          if (typeof percentage != 'number' || percentage < 0 || percentage > 100) {
+            return;
+          }
+
+          var bar = dialog.find('.progress-bar');
+          bar.attr('aria-valuenow', percentage);
+          bar.css('width', percentage + '%');
+        },
+
+        /**
+         * Returns Bootbox Dialog.
+         * 
+         * @return {[type]}    [description]
+         */
+        get: function() {
+          return dialog;
+        },
+
+        /**
+         * Appends content to processingLog.
+         * @param  {[type]} content [description]
+         */
+        append: function (content, type) {
+          if (content instanceof Buffer) {
+            content = content.toString('utf8');
+            // content = document.createTextNode(content);
+          }
+
+          if (typeof type == 'undefined') {
+            type = 'status';
+          }
+
+          switch (type) {
+            case 'error':
+              content = '<div class="error">' + content + '<div>';
+              break;
+            case 'warning':
+              content = '<div class="warning">' + content + '<div>';
+              break;
+            case 'status':
+            default:
+          }
+
+          var log = dialog.find('.processingLog');
+          log.append(content);
+
+          if (settings.auto_scroll) {
+            log.scrollTop(log.get(0).scrollHeight);
+          }
+        },
+
+        /**
+         * Hides Dialog.
+         */
+        hide: function () {
+          dialog.modal('hide');
+        }
+      };
+    })(context);
+  }
+})(DVM);

--- a/drupalvm/core.js
+++ b/drupalvm/core.js
@@ -1,0 +1,17 @@
+// core DVM class
+(function(context) {
+  "use strict";
+
+  // add DVM class to window scope
+  if (!context.DVM) {
+    context.DVM = (function(context) {
+      // private
+
+
+      // public
+      return {
+
+      };
+    })(context);
+  }
+})(window);

--- a/drupalvm/drupalvm.js
+++ b/drupalvm/drupalvm.js
@@ -236,6 +236,13 @@ function checkPrerequisites () {
     version: '0.11.0',
     help: "Vagrant VBGuest Plugin can be installed by running 'vagrant plugin install vagrant-vbguest'."
   }, {
+    // vagrant hostsupdater  plugin
+    name: 'Vagrant HostsUpdater Plugin',
+    command: 'vagrant plugin list',
+    regex: /vagrant-hostsupdater \((\d+\.\d+\.\d+)\)/i,
+    version: '1.0.1',
+    help: "Vagrant HostsUpdater Plugin can be installed by running 'vagrant plugin install vagrant-hostsupdater'."
+  }, {
     // ansible
     name: 'Ansible',
     command: 'ansible --version',
@@ -276,7 +283,7 @@ function checkPrerequisites () {
         if (item.help) {
           // generic help for all platforms
           if (typeof item.help == 'string') {
-            error_text.push('\t' + item.help);
+            error_text.push(item.help);
           }
           // platform-specific help
           else if (typeof item.help == 'object') {

--- a/drupalvm/index.html
+++ b/drupalvm/index.html
@@ -22,22 +22,25 @@
 
     <div class="container-fluid">
       <div class="row">
+        <!-- Sidebar / Menu -->
         <div class="col-sm-3 col-md-2 sidebar">
           <ul class="nav nav-sidebar nav-stacked">
             <li id="menu_drupalvm_dashboard" class="active">
               <a href="#"> <i class="fa fa-drupal fa-4x fa-pull-left"></i> DrupalVM <span class="drupalVMHeaderStatus"></span></a>
             </li>
             <li id="menu_drupalvm_sites">
-                <a href="#"><i class="fa fa-globe"></i> Sites</a>
+              <a href="#"><i class="fa fa-globe"></i> Sites</a>
             </li>
             <li id="menu_drupalvm_tools">
               <a href="#"><i class="fa fa-wrench"></i> Tools<span class="fa arrow"></span></a>
-              </li>
-              <li id="menu_drupalvm_settings">
-                  <a href="#"><i class="fa fa-cogs"></i> Settings</a>
-              </li>
+            </li>
+            <li id="menu_drupalvm_settings">
+              <a href="#"><i class="fa fa-cogs"></i> Settings</a>
+            </li>
           </ul>
         </div>
+
+        <!-- Main content wrapper -->
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
           <div id="reprovisionAlert" class="alert alert-warning" style="display: none;" role="alert">DrupalVM needs to be re-provisioned with your new settings. <a href="#" id="provisionLink">Run this now.</a></div>
 
@@ -235,8 +238,6 @@
               </form>
           </div>
           <!-- END SETTINGS VIEW -->
-
-
         </div>
       </div>
     </div>
@@ -251,14 +252,16 @@
     <script src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 
     <script>
-      require("./drupalvm.js")
+      require("./core.js");
+      require("./components/dialog.js");
+
+      require("./drupalvm.js");
 
       var $ = require('jquery');
       global.jQuery = require("jquery");
       window.$ = $;
       var bootstrap = require('bootstrap');
       var bootbox = require('bootbox');
-
 
       require("./settings.js");
     </script>

--- a/drupalvm/local_config.example.js
+++ b/drupalvm/local_config.example.js
@@ -1,0 +1,11 @@
+// rename this file to local_config.js for changes to take effect
+'use strict';
+
+module.exports.appOnReady = function(mainWindow) {
+  mainWindow.setSize(1400, 900);
+
+  // Open the DevTools.
+  mainWindow.webContents.openDevTools({
+    detach: true
+  });
+};

--- a/drupalvm/local_config.example.js
+++ b/drupalvm/local_config.example.js
@@ -1,11 +1,13 @@
-// rename this file to local_config.js for changes to take effect
 'use strict';
+var event_handler = require('./modules/event_handler');
 
-module.exports.appOnReady = function(mainWindow) {
+event_handler.bind('app', 'ready', function (mainWindow) {
   mainWindow.setSize(1400, 900);
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools({
     detach: true
   });
-};
+});
+
+module.exports = event_handler.trigger

--- a/drupalvm/modules/event_handler/index.js
+++ b/drupalvm/modules/event_handler/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var event_handler = (function () {
+  var handlers = [];
+
+  return {
+    bind: function (module, event, handler) {
+      if (!handlers[module]) {
+        handlers[module] = [];
+      }
+
+      if (!handlers[module][event]) {
+        handlers[module][event] = [];
+      }
+
+      handlers[module][event].push(handler);
+    },
+
+    trigger: function (module, event, args) {
+      if (!handlers[module] || !handlers[module][event]) {
+        return;
+      }
+
+      handlers[module][event].forEach(function (handler) {
+        handler.apply(handler, args);
+      })
+    }
+  };
+})();
+
+module.exports.bind = event_handler.bind;
+module.exports.trigger = event_handler.trigger;

--- a/drupalvm/styles.css
+++ b/drupalvm/styles.css
@@ -1,10 +1,19 @@
 
-#processingLog pre{
+#processingLog pre, pre.processingLog {
   color: #cdcdcd;
   background-color: #fff;
   border: none;
-  height: 200px;
+  height: 340px;
 }
+
+  .processingLog .error {
+    color: #c80f0f;
+  }
+
+  .processingLog .warning {
+    color: #e49701;
+  }
+
 
 #menu_drupalvm_dashboard a {
   padding-top: 25px;
@@ -37,8 +46,16 @@
   margin-left: 10px;
 }
 
+.modal-dialog {
+  width: 900px;
+}
+
+  .modal-dialog .modal-content {
+    height: 500px;
+  }
+
 .modal-backdrop {
-    background-color: #ccc
+  background-color: #ccc
 }
 
 .modal-backdrop.in {

--- a/main.js
+++ b/main.js
@@ -46,13 +46,6 @@ app.on('ready', function() {
 
   mainWindow.setMenuBarVisibility(false);
 
-  // Open the DevTools.
-  /*
-  mainWindow.webContents.openDevTools({
-    detach: true
-  });
-  */
-
   // Emitted when the window is closed.
   mainWindow.on('closed', function () {
 
@@ -60,5 +53,17 @@ app.on('ready', function() {
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     mainWindow = null;
+  });
+
+  // allow local config access to mainWindow
+  var fs = require('fs');
+  var config_path = './drupalvm/local_config.js';
+  fs.exists(config_path, function (exists) {
+    if (exists) {
+      var local = require(config_path);
+      if (local.appOnReady) {
+        local.appOnReady(mainWindow);
+      }
+    }
   });
 });

--- a/main.js
+++ b/main.js
@@ -39,7 +39,8 @@ if (shouldQuit) {
 app.on('ready', function() {
   mainWindow = new BrowserWindow({
     width: 1000,
-    height: 600
+    height: 600,
+    center: true
   });
 
   mainWindow.loadUrl('file://' + __dirname + '/drupalvm/index.html');
@@ -60,10 +61,8 @@ app.on('ready', function() {
   var config_path = './drupalvm/local_config.js';
   fs.exists(config_path, function (exists) {
     if (exists) {
-      var local = require(config_path);
-      if (local.appOnReady) {
-        local.appOnReady(mainWindow);
-      }
+      var trigger = require(config_path);
+      trigger('app', 'ready', [mainWindow]);
     }
   });
 });

--- a/main.js
+++ b/main.js
@@ -13,7 +13,6 @@ require('crash-reporter').start();
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
   if (process.platform != 'darwin') {
-    console.log('Exiting.');
     app.quit();
   }
 });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "electron-prebuilt": "^0.34.1",
     "font-awesome": "^4.4.0",
     "jquery": "^2.1.4",
+    "q": "^1.4.1",
     "yamljs": "^0.2.4"
   }
 }


### PR DESCRIPTION
This PR handles missing dependencies.

Rather than listing missing dependencies on the dashboard page, appropriate error and platform-specific help information is displayed in the startup dialog. I think dealing with one error at a time (as opposed to possibly listing multiple errors in the dashboard table) is a safer approach - we don't run the risk of issues due to cross-dependencies of missing software. 

The PR also includes a new way of handling dialogs (still based on bootbox.dialog), with the following advantages over the previous version:
- ability to have multiple simultaneous dialogs
- cleaner way to update dialog content
- progress bar support
- differentiation between status/warning/error messages

I've refactored the startup dialogs to use this new version, while leaving other (old) dialogs in place for the time being.